### PR TITLE
Load micro plugin when generating protobufs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ proto:
 		for f in $$d/**/proto/*.proto; do \
 			if [ -f "$${GOPATH}/src/github.com/srizzling/gotham/$$f" ]; \
   			then \
-    			protoc --proto_path="$${GOPATH}/src" --go_out=plugin=micro:$${GOPATH}/src $${GOPATH}/src/github.com/srizzling/gotham/$$f; \
+    			protoc --proto_path="$${GOPATH}/src" --go_out=plugins=micro:$${GOPATH}/src $${GOPATH}/src/github.com/srizzling/gotham/$$f; \
 				echo compiled: $$f; \
 			fi\
 		done \


### PR DESCRIPTION
The micro plugin is silently not being loaded which results in the *.pb.go files not having the expected generated code. Specifically, the [`RegisterDRegistryHandler`](https://github.com/srizzling/gotham/blob/master/services/dregistry/main.go#L18) function is not generated, resulting in compiler errors.